### PR TITLE
feat(storage): add Confluence storage format (XHTML) mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ GEMINI.md
 # MkDocs build output
 site/
 
+# Internal work plans / implementation prompts (kept out of version control)
+.plan/
+
 # One-off scripts with credentials
 add_*.py
 create_*.py

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,20 @@ test-*.md
 # Claude Code
 .claude/
 
+# Agent and LLM configuration (kept out of version control)
+AGENTS.md
+CLAUDE.md
+GEMINI.md
+.codex/
+.cursor/
+.cursorrules
+.windsurfrules
+.aider*
+.gemini/
+.antigravity/
+.junie/
+.mcp.json
+
 # MkDocs build output
 site/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - 2026-06-22
+
+### Added
+
+#### Confluence storage format (XHTML) mode
+
+Support for Confluence **storage format** (Atlassian's official format), the
+lossless XHTML representation used by Confluence's REST API
+(`representation: "storage"`). Unlike Markdown, storage format is a pure
+passthrough: tables with colspan/rowspan, macros (`ac:` elements), layouts,
+and all Confluence-specific constructs are preserved exactly.
+
+See the [Confluence storage format documentation](https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html).
+
+**MCP server — new `*_storage` tool family (recommended for agents):**
+- `get_page_storage` — returns raw storage XHTML (pretty-printed); use as input for the other storage write tools.
+- `edit_page_storage` — replaces page body with storage XHTML; validates well-formedness before upload.
+- `create_page_storage` — creates a new page with storage XHTML content.
+- `add_content_storage` — appends/prepends storage XHTML to an existing page.
+
+All storage write tools preserve the human-in-the-loop elicitation confirmation.
+
+The MCP server `instructions` now steer agents toward the `*_storage` tools as
+the preferred choice for content operations.
+
+**New MCP resource:** `confluence://page/{page_id}/storage` — exposes raw
+storage XHTML as an MCP resource.
+
+**CLI:** `--format {md,storage}` flag (default `md`) for `download` and `edit`
+actions. `--format storage` downloads/edits pages in Confluence storage format
+(XHTML, Atlassian's official format) without any Markdown conversion.
+
+**New helpers in `ConfluenceClient`:**
+- `_validate_storage_xhtml(html)` — validates well-formedness, normalises `<br>` and void elements, detects bare `&`; rejects malformed input locally before the API call.
+- `_prettify_storage(html)` — pretty-prints storage XHTML while preserving significant whitespace in `<pre>`, `<ac:plain-text-body>`, and `<ac:plain-text-link-body>`.
+
+### Fixed
+
+- `edit_page_with_editor` with `content_type="html"` (non-interactive mode)
+  previously converted storage XHTML to Markdown and back (`html→md→html`),
+  silently destroying tables and macros. It now validates and uploads the
+  storage XHTML directly.
+
+### Breaking Changes
+
+The following MCP tool names have been renamed with a format suffix to make
+room for the new `*_storage` variants. Update any MCP client configurations
+that reference the old names:
+
+| Old name | New name |
+|---|---|
+| `get_page` | `get_page_md` |
+| `edit_page` | `edit_page_md` |
+| `create_page` | `create_page_md` |
+| `add_content_to_page` | `add_content_md` |
+
+The old names are fully removed; no aliases are provided.
+
 ## [0.1.0] - 2026-02-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -418,6 +418,21 @@ Restart Claude Desktop after editing the config file.
 
 Pages are also accessible as MCP resources via `confluence://page/{page_id}`.
 
+### Write protection (human-in-the-loop)
+
+When the MCP client supports
+[elicitation](https://modelcontextprotocol.io/docs/concepts/elicitation),
+`create_page`, `edit_page`, and `add_content_to_page` prompt for explicit
+confirmation before executing. Clients that do not support elicitation
+(automated agents, older clients) proceed without the prompt.
+
+The confirmation form has two fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `confirm` | bool | `true` to proceed, `false` to abort |
+| `remember` | bool | `true` to skip confirmation for the rest of the session |
+
 ### MCP Troubleshooting
 
 **Tools time out in Claude Desktop** — The MCP server process is started once per Claude Desktop session and does not auto-restart after long idle periods. If tool calls fail or time out, restart Claude Desktop to re-establish the connection.

--- a/README.md
+++ b/README.md
@@ -405,26 +405,44 @@ Restart Claude Desktop after editing the config file.
 
 ### Available MCP tools
 
+**Navigation / search** (no format dimension):
+
 | Tool | Description |
 |------|-------------|
 | `search_pages` | Search via CQL or free-text query |
-| `get_page` | Get full page content (markdown + metadata) by URL |
 | `list_recent_pages` | Pages recently modified by you |
 | `list_spaces` | All accessible spaces |
 | `list_children` | Direct child pages of a page |
-| `create_page` | Create a new page with markdown content |
-| `edit_page` | Replace a page's full content |
-| `add_content_to_page` | Append or prepend content to a page |
 
-Pages are also accessible as MCP resources via `confluence://page/{page_id}`.
+**`*_storage` family — RECOMMENDED for agents** (Confluence storage format, lossless):
+
+| Tool | Description |
+|------|-------------|
+| `get_page_storage` | Get page in Confluence storage format (XHTML) — preserves tables, macros, layouts |
+| `edit_page_storage` | Replace page body with storage XHTML — lossless, validates before upload |
+| `create_page_storage` | Create a page with storage XHTML content |
+| `add_content_storage` | Append/prepend storage XHTML to a page |
+
+**`*_md` family** (Markdown, convenient but lossy for complex tables/macros):
+
+| Tool | Description |
+|------|-------------|
+| `get_page_md` | Get page content converted to Markdown |
+| `edit_page_md` | Replace page body with Markdown content |
+| `create_page_md` | Create a page with Markdown content |
+| `add_content_md` | Append/prepend Markdown content to a page |
+
+Pages are also accessible as MCP resources:
+- `confluence://page/{page_id}` — Markdown
+- `confluence://page/{page_id}/storage` — Confluence storage format (XHTML)
 
 ### Write protection (human-in-the-loop)
 
 When the MCP client supports
 [elicitation](https://modelcontextprotocol.io/docs/concepts/elicitation),
-`create_page`, `edit_page`, and `add_content_to_page` prompt for explicit
-confirmation before executing. Clients that do not support elicitation
-(automated agents, older clients) proceed without the prompt.
+all write tools (`*_storage` and `*_md`) prompt for explicit confirmation
+before executing. Clients that do not support elicitation (automated agents,
+older clients) proceed without the prompt.
 
 The confirmation form has two fields:
 
@@ -447,7 +465,46 @@ confluence-markdown-mcp  # should block waiting for stdin (Ctrl-C to exit)
 confluence-markdown --action test-auth
 ```
 
-**`create_page` or `edit_page` returns no output** — These operations print progress to stdout, which would corrupt the MCP JSON-RPC channel. The server automatically redirects such output to stderr so it only appears in `~/Library/Logs/Claude/mcp-server-confluence.log`.
+**`create_page_md` or `edit_page_md` returns no output** — These operations print progress to stdout, which would corrupt the MCP JSON-RPC channel. The server automatically redirects such output to stderr so it only appears in `~/Library/Logs/Claude/mcp-server-confluence.log`.
+
+---
+
+## Confluence storage format mode
+
+Confluence stores pages in **storage format** — Atlassian's official XHTML format with `ac:` (Atlassian Confluence — macros, layouts, tasks) and `ri:` (resource identifiers — attachments, users, pages) namespaced elements. This is the same representation returned by the REST API's `representation: "storage"` parameter. See the [official Atlassian documentation](https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html).
+
+The default Markdown mode converts storage format to Markdown and back, which is lossy for:
+- Tables with `colspan`/`rowspan` or multi-paragraph cells
+- Confluence macros (`ac:structured-macro`, `ac:task-list`, …)
+- Layouts and nested content
+
+**Storage format mode is a pure passthrough** — no conversion happens. Read the raw XHTML, edit it, upload it verbatim.
+
+### When to use storage format vs. Markdown
+
+| Situation | Recommended mode |
+|-----------|-----------------|
+| Simple text pages, bullet lists | Markdown (default) |
+| Pages with complex tables | Storage format |
+| Pages with Confluence macros | Storage format |
+| Agents editing via MCP | Storage format (`*_storage` tools) |
+| Summarising a page for a human | Markdown (`*_md` tools) |
+
+### CLI usage
+
+```bash
+# Download in storage format (writes pretty-printed XHTML with comment header)
+confluence-markdown download https://wiki.example.com/... --format storage -o page.html
+
+# Edit in storage format (non-interactive: pass XHTML directly)
+confluence-markdown edit https://wiki.example.com/... --format storage --content '<p>Updated</p>'
+```
+
+The `--format storage` flag defaults the download extension to `.html` (for editor syntax highlighting); the content is Confluence storage format XHTML, not HTML5.
+
+### Validation
+
+Storage XHTML is validated locally before every upload. Malformed input — unclosed tags, bare `&`, non-self-closing void elements — is rejected with a clear error message before any API call is made.
 
 ---
 

--- a/src/confluence_markdown/cli.py
+++ b/src/confluence_markdown/cli.py
@@ -120,6 +120,18 @@ def create_parser() -> argparse.ArgumentParser:
         help="Type of content to add",
     )
     parser.add_argument(
+        "--format",
+        choices=["md", "storage"],
+        default="md",
+        dest="fmt",
+        help=(
+            "Page format for download/read/edit. "
+            "'md' (default) converts to Markdown. "
+            "'storage' uses Confluence storage format (XHTML, Atlassian's official format) "
+            "for lossless round-trips — preserves tables, macros, and layouts."
+        ),
+    )
+    parser.add_argument(
         "--append",
         action="store_true",
         default=True,
@@ -674,9 +686,10 @@ def handle_download(client: ConfluenceClient, args: argparse.Namespace) -> None:
 
         print(f"Downloaded {len(results)} pages to {output_dir}/")
     else:
-        markdown_content = client.download_as_markdown(args.url, args.output)
+        fmt = getattr(args, "fmt", "md") or "md"
+        content = client.download_page(args.url, args.output, fmt=fmt)
         if not args.output:
-            print(markdown_content)
+            print(content)
         print(f"Page URL: {args.url}")
 
 
@@ -725,7 +738,11 @@ def handle_edit(client: ConfluenceClient, args: argparse.Namespace) -> None:
         raise ConfigurationError("URL is required for edit action")
 
     content = getattr(args, "content", None) or None
-    content_type = getattr(args, "content_type", "markdown") or "markdown"
+    fmt = getattr(args, "fmt", "md") or "md"
+    if fmt == "storage":
+        content_type = "storage"
+    else:
+        content_type = getattr(args, "content_type", "markdown") or "markdown"
 
     result = client.edit_page_with_editor(args.url, content=content, content_type=content_type)
     if result is None:

--- a/src/confluence_markdown/client.py
+++ b/src/confluence_markdown/client.py
@@ -441,28 +441,45 @@ class ConfluenceClient:
             for s in results
         ]
 
-    def download_as_markdown(
-        self, page_url: str, output_file: Optional[str] = None
+    def download_page(
+        self,
+        page_url: str,
+        output_file: Optional[str] = None,
+        fmt: str = "md",
     ) -> str:
-        """
-        Download page content and convert to markdown.
+        """Download a page in the requested format.
 
         Args:
-            page_url: Full URL to the Confluence page
-            output_file: Optional file path to save markdown
+            page_url: Full URL to the Confluence page.
+            output_file: Optional file path to save the output.
+            fmt: ``"md"`` (default) for Markdown, or ``"storage"`` for
+                 Confluence storage format (XHTML), Atlassian's official
+                 native page format (``representation: "storage"`` in the
+                 REST API).
 
         Returns:
-            Markdown content as string
+            Page content as a string (Markdown or storage XHTML).
         """
         page_data = self.get_page_by_url(page_url)
+        storage_value = page_data["body"]["storage"]["value"]
 
-        # Extract HTML content
-        html_content = page_data["body"]["storage"]["value"]
+        if fmt == "storage":
+            # Lossless passthrough: pretty-print storage XHTML for human editing.
+            pretty = self._prettify_storage(storage_value)
+            header = (
+                f"<!-- Page ID: {page_data['id']}, "
+                f"Version: {page_data['version']['number']}, "
+                f"Title: {page_data['title']} -->\n"
+            )
+            full_content = header + pretty
+            if output_file:
+                with open(output_file, "w", encoding="utf-8") as f:
+                    f.write(full_content)
+                print(f"Storage XHTML saved to: {output_file}")
+            return full_content
 
-        # Convert HTML to Markdown
-        markdown_content = self._html_to_markdown(html_content)
-
-        # Add metadata header
+        # Default: Markdown
+        markdown_content = self._html_to_markdown(storage_value)
         safe_title = self._escape_markdown_heading(page_data["title"])
         metadata = f"""# {safe_title}
 
@@ -474,10 +491,8 @@ class ConfluenceClient:
 ---
 
 """
-
         full_markdown = metadata + markdown_content
 
-        # Save to file if specified
         if output_file:
             with open(output_file, "w", encoding="utf-8") as f:
                 f.write(full_markdown)
@@ -1818,6 +1833,108 @@ More content...
         pattern = r"<!-- CONFLUENCE_MACROS_START\n(.*?)\nCONFLUENCE_MACROS_END -->\n?"
         return re.sub(pattern, "", content, flags=re.DOTALL)
 
+    # ── Confluence storage format (XHTML) helpers ─────────────────────────────
+
+    # Void HTML elements that must be self-closing in XML/XHTML
+    _VOID_ELEMENTS = frozenset(
+        ["br", "hr", "img", "input", "link", "meta", "area", "base",
+         "col", "embed", "param", "source", "track", "wbr"]
+    )
+
+    # Elements where internal whitespace is semantically significant
+    _PRESERVE_WS_TAGS = ("ac:plain-text-body", "ac:plain-text-link-body", "pre")
+
+    # Namespace declarations common in Confluence storage format
+    _STORAGE_NS = (
+        'xmlns:ac="http://atlassian.com/content/ac" '
+        'xmlns:ri="http://atlassian.com/content/ri" '
+        'xmlns:at="http://atlassian.com/content/at"'
+    )
+
+    def _validate_storage_xhtml(self, html: str) -> tuple[bool, str | None]:
+        """Validate Confluence storage format XHTML for well-formedness.
+
+        Normalizes ``<br>`` → ``<br/>`` and void elements before checking.
+        Returns ``(True, None)`` on success or ``(False, error_message)`` on
+        failure. Call this before every PUT/POST in storage mode so malformed
+        input fails locally with a clear message instead of an opaque HTTP 400.
+        """
+        import xml.etree.ElementTree as ET
+
+        # Step 1: normalize void elements to be self-closing
+        content = html
+        for tag in self._VOID_ELEMENTS:
+            # Match <tag> or <tag attrs> NOT already self-closed and NOT followed
+            # by </tag> (i.e. the element is empty and must be self-closed).
+            content = re.sub(
+                rf'<({re.escape(tag)})(\s[^>]*)?(?<!/)>',
+                r'<\1\2/>',
+                content,
+                flags=re.IGNORECASE,
+            )
+
+        # Step 2: detect bare & not part of a valid XML entity or char ref
+        bare_amp = re.search(
+            r'&(?!(?:#\d+|#x[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);)',
+            content,
+        )
+        if bare_amp:
+            pos = bare_amp.start()
+            ctx = content[max(0, pos - 20): pos + 40]
+            return (
+                False,
+                f"Unescaped '&' found near: …{ctx!r}… — replace with '&amp;'.",
+            )
+
+        # Step 3: try parsing as XML with known Confluence namespace declarations
+        wrapped = f'<_root {self._STORAGE_NS}>{content}</_root>'
+        try:
+            ET.fromstring(wrapped)
+        except ET.ParseError as exc:
+            return (
+                False,
+                f"Storage XHTML is not well-formed: {exc}. "
+                "Check for unclosed tags, mismatched elements, or invalid characters.",
+            )
+
+        return True, None
+
+    def _prettify_storage(self, html: str) -> str:
+        """Pretty-print Confluence storage format XHTML for human editing.
+
+        Preserves significant whitespace inside ``<pre>``,
+        ``<ac:plain-text-body>``, and ``<ac:plain-text-link-body>`` elements
+        so that code block content is not indented by the prettifier.
+        Confluence re-normalizes storage on save, so this is cosmetic only.
+        """
+        import uuid
+
+        preserved: dict[str, str] = {}
+        content = html
+
+        for tag in self._PRESERVE_WS_TAGS:
+            pattern = re.compile(
+                rf'(<{re.escape(tag)}(?:\s[^>]*)?>)(.*?)(</{re.escape(tag)}>)',
+                re.DOTALL | re.IGNORECASE,
+            )
+
+            def _replacer(m: re.Match, _tag: str = tag) -> str:
+                key = f"__PRESERVE_{uuid.uuid4().hex}__"
+                preserved[key] = m.group(0)
+                return key
+
+            content = pattern.sub(_replacer, content)
+
+        soup = BeautifulSoup(content, "html.parser")
+        pretty = soup.prettify()
+
+        for key, original in preserved.items():
+            pretty = pretty.replace(key, original)
+
+        return pretty
+
+    # ── End storage helpers ────────────────────────────────────────────────────
+
     def _markdown_to_html(self, markdown_content: str) -> str:
         """Convert markdown to HTML using proper markdown parser."""
         # Use markdown library with table support and HTML passthrough
@@ -1877,11 +1994,37 @@ More content...
 
         try:
             if content is not None:
-                # Non-interactive mode: write provided content directly to temp file
+                # Non-interactive mode: write provided content directly.
                 self._debug("Non-interactive edit: using provided content")
-                if content_type == "html":
-                    new_markdown, _ = self._html_to_markdown_with_macros(content)
-                    write_content = new_markdown
+                if content_type in ("html", "storage"):
+                    # Storage XHTML passthrough: validate then PUT directly,
+                    # bypassing the markdown pipeline entirely.  This fixes the
+                    # former html→markdown→html round-trip that was lossy for
+                    # tables and macros.
+                    ok, err = self._validate_storage_xhtml(content)
+                    if not ok:
+                        raise ValueError(
+                            f"Invalid Confluence storage format XHTML: {err}"
+                        )
+                    self._debug("Storage passthrough validated; uploading directly")
+                    update_data = {
+                        "version": {"number": page_data["version"]["number"] + 1},
+                        "title": page_data["title"],
+                        "type": "page",
+                        "body": {
+                            "storage": {"value": content, "representation": "storage"}
+                        },
+                    }
+                    url = f"{self.api_base}/content/{page_data['id']}"
+                    response = self._request("PUT", url, json=update_data)
+                    self._debug(f"Storage PUT response: {response.status_code}")
+                    if response.status_code == 409:
+                        raise RuntimeError(
+                            "Confluence rejected the update due to a version conflict. "
+                            "Refresh the page and try again."
+                        )
+                    response.raise_for_status()
+                    return response.json()
                 else:
                     write_content = content
                 with open(temp_file_path, "w") as f:

--- a/src/confluence_markdown/mcp_server.py
+++ b/src/confluence_markdown/mcp_server.py
@@ -10,11 +10,19 @@ from contextlib import contextmanager
 from typing import Any
 
 try:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.elicitation import (
+        AcceptedElicitation,
+        CancelledElicitation,
+        DeclinedElicitation,
+    )
+    from mcp.server.fastmcp import Context, FastMCP
+    from mcp.types import ClientCapabilities, ElicitationCapability, ToolAnnotations
 except ImportError as exc:
     raise SystemExit(
         "The 'mcp' extra is required: uv pip install -e '.[mcp]'"
     ) from exc
+
+from pydantic import BaseModel, Field
 
 from .client import ConfluenceClient
 from .config import ConfigManager
@@ -28,6 +36,51 @@ mcp = FastMCP(
 )
 
 _client: ConfluenceClient | None = None
+_writes_confirmed_session: bool = False
+
+
+class WriteConfirmation(BaseModel):
+    """Schema for human-in-the-loop confirmation of write operations."""
+
+    confirm: bool = Field(description="Confirm the write operation.")
+    remember: bool = Field(default=False, description="Skip confirmation for the rest of this session.")
+
+
+async def _confirm_write(ctx: Context, summary: str) -> None:
+    """Ask the user to confirm a destructive write operation via MCP elicitation.
+
+    If the client does not support elicitation the write proceeds without
+    confirmation — protection is opportunistic, not a hard gate.
+    Raises PermissionError only when a human explicitly declines or cancels.
+    """
+    global _writes_confirmed_session
+    if _writes_confirmed_session:
+        return
+
+    if not ctx.session.check_client_capability(
+        ClientCapabilities(elicitation=ElicitationCapability())
+    ):
+        return
+
+    result = await ctx.elicit(
+        message=(
+            f"This action will modify Confluence content.\n\n"
+            f"Operation: {summary}\n\n"
+            "Do you want to proceed?"
+        ),
+        schema=WriteConfirmation,
+    )
+
+    match result:
+        case AcceptedElicitation(data=data) if data is not None:
+            if not data.confirm:
+                raise PermissionError("Write operation rejected by user.")
+            if data.remember:
+                _writes_confirmed_session = True
+        case DeclinedElicitation() | CancelledElicitation():
+            raise PermissionError("Write operation was declined or cancelled.")
+        case _:
+            raise PermissionError("Unexpected elicitation result; write blocked.")
 
 
 def _get_client() -> ConfluenceClient:
@@ -89,7 +142,7 @@ def _ok(data: Any) -> str:
 # ── Read tools ────────────────────────────────────────────────────────────────
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False))
 def search_pages(
     cql: str | None = None,
     query: str | None = None,
@@ -118,7 +171,7 @@ def search_pages(
         raise RuntimeError(str(e)) from e
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False))
 def get_page(page_url: str) -> str:
     """Get the full content of a Confluence page by its URL.
 
@@ -137,7 +190,7 @@ def get_page(page_url: str) -> str:
         raise RuntimeError(str(e)) from e
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False))
 def list_recent_pages(limit: int = 10) -> str:
     """List Confluence pages recently modified by the authenticated user.
 
@@ -153,7 +206,7 @@ def list_recent_pages(limit: int = 10) -> str:
         raise RuntimeError(str(e)) from e
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False))
 def list_spaces(limit: int = 50) -> str:
     """List all Confluence spaces accessible by the authenticated user.
 
@@ -168,7 +221,7 @@ def list_spaces(limit: int = 50) -> str:
         raise RuntimeError(str(e)) from e
 
 
-@mcp.tool()
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False))
 def list_children(page_url: str, limit: int = 50) -> str:
     """List the direct child pages of a Confluence page.
 
@@ -187,11 +240,12 @@ def list_children(page_url: str, limit: int = 50) -> str:
 # ── Write tools ───────────────────────────────────────────────────────────────
 
 
-@mcp.tool()
-def create_page(
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))
+async def create_page(
     space_key: str,
     title: str,
     content: str,
+    ctx: Context,
     parent_id: str | None = None,
 ) -> str:
     """Create a new Confluence page with markdown content.
@@ -205,9 +259,11 @@ def create_page(
 
     Returns a JSON object with the new page's id, title, and url.
     """
+    await _confirm_write(ctx, f"Create page '{title}' in space '{space_key}'")
     client = _get_client()
     with _silence_stdout():
         try:
+            # TODO: wrap blocking client call in asyncio.to_thread if concurrency needed
             result = client.create_page(
                 space_key=space_key,
                 title=title,
@@ -225,8 +281,8 @@ def create_page(
     })
 
 
-@mcp.tool()
-def edit_page(page_url: str, content: str) -> str:
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))
+async def edit_page(page_url: str, content: str, ctx: Context) -> str:
     """Replace the full body of a Confluence page with new markdown content.
 
     The existing page content is completely overwritten. Use add_content_to_page
@@ -234,9 +290,11 @@ def edit_page(page_url: str, content: str) -> str:
 
     Returns a JSON object with the page's id, title, new version number, and url.
     """
+    await _confirm_write(ctx, f"Overwrite full content of page at {page_url}")
     client = _get_client()
     with _silence_stdout():
         try:
+            # TODO: wrap blocking client call in asyncio.to_thread if concurrency needed
             result = client.edit_page_with_editor(
                 page_url, content=content, content_type="markdown"
             )
@@ -251,10 +309,11 @@ def edit_page(page_url: str, content: str) -> str:
     })
 
 
-@mcp.tool()
-def add_content_to_page(
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))
+async def add_content_to_page(
     page_url: str,
     content: str,
+    ctx: Context,
     append: bool = True,
 ) -> str:
     """Add markdown content to an existing Confluence page without replacing it.
@@ -266,8 +325,11 @@ def add_content_to_page(
 
     Returns a JSON object with the page's id, title, and new version number.
     """
+    position = "append to" if append else "prepend to"
+    await _confirm_write(ctx, f"Add content ({position}) page at {page_url}")
     client = _get_client()
     try:
+        # TODO: wrap blocking client call in asyncio.to_thread if concurrency needed
         result = client.add_content_to_page(
             page_url, content, append=append, content_type="markdown"
         )

--- a/src/confluence_markdown/mcp_server.py
+++ b/src/confluence_markdown/mcp_server.py
@@ -1,4 +1,24 @@
-"""MCP stdio server exposing Confluence operations as tools."""
+"""MCP stdio server exposing Confluence operations as tools.
+
+Tool families
+─────────────
+*_storage (RECOMMENDED for agents): use the Confluence storage format
+    (XHTML) — Atlassian's native page format — and preserve tables
+    (colspan/rowspan), macros (ac: elements), and layouts losslessly.
+    Equivalent to ``representation: "storage"`` in the REST API.
+
+*_md: convert content to/from Markdown for human readability.  Convenient
+    but lossy for tables with colspan/rowspan and Confluence macros.  Prefer
+    the *_storage variants unless you specifically need Markdown output.
+
+Navigation / search tools (search_pages, list_recent_pages, list_spaces,
+list_children) have no format dimension and are left unsuffixed.
+
+BREAKING CHANGE from the previous release: the tools formerly named
+``get_page``, ``edit_page``, ``create_page``, and ``add_content_to_page``
+have been renamed with the ``_md`` suffix.  Update any MCP configurations
+that reference the old names.
+"""
 
 from __future__ import annotations
 
@@ -32,7 +52,19 @@ logger = logging.getLogger(__name__)
 
 mcp = FastMCP(
     "confluence",
-    instructions="Read and write Confluence Data Center pages",
+    instructions=(
+        "Read and write Confluence Data Center pages.\n\n"
+        "IMPORTANT — tool selection:\n"
+        "• Prefer the *_storage tools for all content operations. They use the "
+        "Confluence storage format (XHTML) — Atlassian's official native page "
+        "format — and preserve tables (colspan/rowspan), macros (ac: elements), "
+        "and layouts losslessly. This is equivalent to representation:\"storage\" "
+        "in the Confluence REST API.\n"
+        "• Use the *_md tools only when you specifically need human-readable "
+        "Markdown output (e.g. when summarising a page for a user).\n"
+        "• Navigation / search tools have no format dimension: search_pages, "
+        "list_recent_pages, list_spaces, list_children."
+    ),
 )
 
 _client: ConfluenceClient | None = None
@@ -139,7 +171,7 @@ def _ok(data: Any) -> str:
     return json.dumps(data, ensure_ascii=False, indent=2)
 
 
-# ── Read tools ────────────────────────────────────────────────────────────────
+# ── Navigation / search tools (no format dimension) ───────────────────────────
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False))
@@ -172,25 +204,6 @@ def search_pages(
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False))
-def get_page(page_url: str) -> str:
-    """Get the full content of a Confluence page by its URL.
-
-    Accepts any Confluence page URL, e.g.
-      https://wiki.example.com/pages/viewpage.action?pageId=12345
-      https://wiki.example.com/display/SPACE/Page+Title
-
-    Returns a JSON object with: id, title, space, version, url, and the page body
-    converted to markdown.
-    """
-    client = _get_client()
-    try:
-        result = client.read_page_content(page_url)
-        return _ok(result)
-    except ConfluenceError as e:
-        raise RuntimeError(str(e)) from e
-
-
-@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False))
 def list_recent_pages(limit: int = 10) -> str:
     """List Confluence pages recently modified by the authenticated user.
 
@@ -211,7 +224,8 @@ def list_spaces(limit: int = 50) -> str:
     """List all Confluence spaces accessible by the authenticated user.
 
     Returns up to `limit` spaces (max 50). Each entry includes key, name, type, and url.
-    Use the space key (e.g. "DEV", "DOCS") when creating pages with create_page.
+    Use the space key (e.g. "DEV", "DOCS") when creating pages with create_page_md or
+    create_page_storage.
     """
     client = _get_client()
     try:
@@ -237,25 +251,258 @@ def list_children(page_url: str, limit: int = 50) -> str:
         raise RuntimeError(str(e)) from e
 
 
-# ── Write tools ───────────────────────────────────────────────────────────────
+# ── *_storage read/write tools (RECOMMENDED) ─────────────────────────────────
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False))
+def get_page_storage(page_url: str) -> str:
+    """RECOMMENDED — Get the raw Confluence storage format (XHTML) of a page.
+
+    Returns the page body in Confluence storage format (XHTML) — Atlassian's
+    official native page format (``representation: "storage"`` in the REST API).
+    This is a lossless representation: tables with colspan/rowspan, macros
+    (ac: elements), layouts, and all other Confluence-specific constructs are
+    preserved verbatim.
+
+    Use this tool (and the other *_storage tools) whenever you intend to edit
+    or analyse page content — it is the preferred tool family for agents.
+
+    Accepts any Confluence page URL, e.g.
+      https://wiki.example.com/pages/viewpage.action?pageId=12345
+      https://wiki.example.com/display/SPACE/Page+Title
+
+    Returns a JSON object with: id, title, space, version, url, and
+    ``storage_content`` (pretty-printed storage XHTML ready for editing).
+    """
+    client = _get_client()
+    try:
+        result = client.read_page_content(page_url)
+    except ConfluenceError as e:
+        raise RuntimeError(str(e)) from e
+    return _ok({
+        "id": result["id"],
+        "title": result["title"],
+        "space": result["space"],
+        "space_key": result["space_key"],
+        "version": result["version"],
+        "url": result["url"],
+        "storage_content": client._prettify_storage(result["html_content"]),
+    })
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))
-async def create_page(
+async def edit_page_storage(page_url: str, content: str, ctx: Context) -> str:
+    """RECOMMENDED — Replace the full body of a Confluence page with storage format (XHTML).
+
+    Accepts content in Confluence storage format (XHTML) — Atlassian's official
+    native page format — and uploads it losslessly via ``representation: "storage"``.
+    Tables with colspan/rowspan, macros (ac: elements), layouts, and all other
+    Confluence constructs are preserved exactly.
+
+    The content is validated for well-formedness before upload; malformed XHTML
+    is rejected locally with a clear error message (no opaque HTTP 400).
+
+    Use get_page_storage first to read the current storage content, then supply
+    the modified XHTML here.
+
+    Prefer this tool over edit_page_md for any page that contains tables, macros,
+    or complex layouts.  Use edit_page_md only when you specifically need to supply
+    Markdown input.
+
+    Returns a JSON object with the page's id, title, new version number, and url.
+    """
+    await _confirm_write(ctx, f"Overwrite full content of page at {page_url} (storage format)")
+    client = _get_client()
+    ok, err = client._validate_storage_xhtml(content)
+    if not ok:
+        raise ValueError(f"Invalid Confluence storage format XHTML: {err}")
+    with _silence_stdout():
+        try:
+            result = client.edit_page_with_editor(
+                page_url, content=content, content_type="storage"
+            )
+        except ConfluenceError as e:
+            raise RuntimeError(str(e)) from e
+    page_id = result["id"]
+    return _ok({
+        "id": page_id,
+        "title": result.get("title"),
+        "version": result.get("version", {}).get("number"),
+        "url": f"{client.base_url}/pages/viewpage.action?pageId={page_id}",
+    })
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))
+async def create_page_storage(
     space_key: str,
     title: str,
     content: str,
     ctx: Context,
     parent_id: str | None = None,
 ) -> str:
-    """Create a new Confluence page with markdown content.
+    """RECOMMENDED — Create a new Confluence page with storage format (XHTML) content.
+
+    Accepts the page body in Confluence storage format (XHTML) — Atlassian's
+    official native page format — and creates the page losslessly.  Tables,
+    macros, layouts, and all Confluence-specific constructs are preserved.
+
+    The content is validated for well-formedness before upload.
 
     Args:
         space_key: Key of the target space (e.g. "DEV", "DOCS"). Use list_spaces to find it.
         title: Page title (must be unique within the space).
-        content: Page body in markdown format.
-        parent_id: Optional numeric ID of the parent page. When omitted the page is created
-                   at the space root. Use list_children or get_page to find parent IDs.
+        content: Page body in Confluence storage format (XHTML).
+        parent_id: Optional numeric ID of the parent page.
+
+    Prefer this tool over create_page_md when the page content contains tables,
+    macros, or complex layouts.
+
+    Returns a JSON object with the new page's id, title, and url.
+    """
+    await _confirm_write(ctx, f"Create page '{title}' in space '{space_key}' (storage format)")
+    client = _get_client()
+    ok, err = client._validate_storage_xhtml(content)
+    if not ok:
+        raise ValueError(f"Invalid Confluence storage format XHTML: {err}")
+    with _silence_stdout():
+        try:
+            result = client.create_page(
+                space_key=space_key,
+                title=title,
+                content=content,
+                parent_id=parent_id,
+                content_type="html",
+            )
+        except ConfluenceError as e:
+            raise RuntimeError(str(e)) from e
+    page_id = result["id"]
+    return _ok({
+        "id": page_id,
+        "title": result.get("title", title),
+        "url": f"{client.base_url}/pages/viewpage.action?pageId={page_id}",
+    })
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))
+async def add_content_storage(
+    page_url: str,
+    content: str,
+    ctx: Context,
+    append: bool = True,
+) -> str:
+    """RECOMMENDED — Add storage format (XHTML) content to an existing Confluence page.
+
+    Appends or prepends content in Confluence storage format (XHTML) —
+    Atlassian's official native page format — without replacing the existing
+    body.  Tables, macros, and layouts are preserved losslessly.
+
+    The supplied content is validated for well-formedness before upload.
+
+    Args:
+        page_url: URL of the page to update.
+        content: Content to add in Confluence storage format (XHTML).
+        append: True (default) to add after existing content; False to prepend.
+
+    Prefer this tool over add_content_md when adding content with tables or macros.
+
+    Returns a JSON object with the page's id, title, and new version number.
+    """
+    client = _get_client()
+    ok, err = client._validate_storage_xhtml(content)
+    if not ok:
+        raise ValueError(f"Invalid Confluence storage format XHTML: {err}")
+    position = "append to" if append else "prepend to"
+    await _confirm_write(ctx, f"Add storage content ({position}) page at {page_url}")
+    try:
+        result = client.add_content_to_page(
+            page_url, content, append=append, content_type="html"
+        )
+    except ConfluenceError as e:
+        raise RuntimeError(str(e)) from e
+    return _ok({
+        "id": result["id"],
+        "title": result.get("title"),
+        "version": result.get("version", {}).get("number"),
+    })
+
+
+# ── *_md read/write tools ─────────────────────────────────────────────────────
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False))
+def get_page_md(page_url: str) -> str:
+    """Get the content of a Confluence page converted to Markdown.
+
+    Convenient for human-readable summaries, but lossy: tables with
+    colspan/rowspan, macros (ac: elements), and complex layouts cannot be
+    faithfully represented in Markdown.  Prefer get_page_storage when you
+    intend to edit or re-upload the content.
+
+    Accepts any Confluence page URL, e.g.
+      https://wiki.example.com/pages/viewpage.action?pageId=12345
+      https://wiki.example.com/display/SPACE/Page+Title
+
+    Returns a JSON object with: id, title, space, version, url, and the page
+    body converted to Markdown.
+    """
+    client = _get_client()
+    try:
+        result = client.read_page_content(page_url)
+        return _ok(result)
+    except ConfluenceError as e:
+        raise RuntimeError(str(e)) from e
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))
+async def edit_page_md(page_url: str, content: str, ctx: Context) -> str:
+    """Replace the full body of a Confluence page with Markdown content.
+
+    Convenient for simple pages, but lossy for tables with colspan/rowspan,
+    macros (ac: elements), and complex layouts.  Prefer edit_page_storage for
+    any page that contains such constructs.
+
+    The existing page content is completely overwritten.  Use add_content_md
+    if you only want to append or prepend without discarding the current body.
+
+    Returns a JSON object with the page's id, title, new version number, and url.
+    """
+    await _confirm_write(ctx, f"Overwrite full content of page at {page_url}")
+    client = _get_client()
+    with _silence_stdout():
+        try:
+            result = client.edit_page_with_editor(
+                page_url, content=content, content_type="markdown"
+            )
+        except ConfluenceError as e:
+            raise RuntimeError(str(e)) from e
+    page_id = result["id"]
+    return _ok({
+        "id": page_id,
+        "title": result.get("title"),
+        "version": result.get("version", {}).get("number"),
+        "url": f"{client.base_url}/pages/viewpage.action?pageId={page_id}",
+    })
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))
+async def create_page_md(
+    space_key: str,
+    title: str,
+    content: str,
+    ctx: Context,
+    parent_id: str | None = None,
+) -> str:
+    """Create a new Confluence page with Markdown content.
+
+    Convenient for simple pages, but lossy for tables with colspan/rowspan,
+    macros, and complex layouts.  Prefer create_page_storage for pages that
+    contain such constructs.
+
+    Args:
+        space_key: Key of the target space (e.g. "DEV", "DOCS"). Use list_spaces to find it.
+        title: Page title (must be unique within the space).
+        content: Page body in Markdown format.
+        parent_id: Optional numeric ID of the parent page.
 
     Returns a JSON object with the new page's id, title, and url.
     """
@@ -263,7 +510,6 @@ async def create_page(
     client = _get_client()
     with _silence_stdout():
         try:
-            # TODO: wrap blocking client call in asyncio.to_thread if concurrency needed
             result = client.create_page(
                 space_key=space_key,
                 title=title,
@@ -282,41 +528,16 @@ async def create_page(
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))
-async def edit_page(page_url: str, content: str, ctx: Context) -> str:
-    """Replace the full body of a Confluence page with new markdown content.
-
-    The existing page content is completely overwritten. Use add_content_to_page
-    if you only want to append or prepend without discarding the current body.
-
-    Returns a JSON object with the page's id, title, new version number, and url.
-    """
-    await _confirm_write(ctx, f"Overwrite full content of page at {page_url}")
-    client = _get_client()
-    with _silence_stdout():
-        try:
-            # TODO: wrap blocking client call in asyncio.to_thread if concurrency needed
-            result = client.edit_page_with_editor(
-                page_url, content=content, content_type="markdown"
-            )
-        except ConfluenceError as e:
-            raise RuntimeError(str(e)) from e
-    page_id = result["id"]
-    return _ok({
-        "id": page_id,
-        "title": result.get("title"),
-        "version": result.get("version", {}).get("number"),
-        "url": f"{client.base_url}/pages/viewpage.action?pageId={page_id}",
-    })
-
-
-@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))
-async def add_content_to_page(
+async def add_content_md(
     page_url: str,
     content: str,
     ctx: Context,
     append: bool = True,
 ) -> str:
-    """Add markdown content to an existing Confluence page without replacing it.
+    """Add Markdown content to an existing Confluence page without replacing it.
+
+    Convenient for simple content, but lossy for tables with colspan/rowspan,
+    macros, and complex layouts.  Prefer add_content_storage for such cases.
 
     Args:
         page_url: URL of the page to update.
@@ -329,7 +550,6 @@ async def add_content_to_page(
     await _confirm_write(ctx, f"Add content ({position}) page at {page_url}")
     client = _get_client()
     try:
-        # TODO: wrap blocking client call in asyncio.to_thread if concurrency needed
         result = client.add_content_to_page(
             page_url, content, append=append, content_type="markdown"
         )
@@ -342,15 +562,16 @@ async def add_content_to_page(
     })
 
 
-# ── MCP Resource ──────────────────────────────────────────────────────────────
+# ── MCP Resources ─────────────────────────────────────────────────────────────
 
 
 @mcp.resource("confluence://page/{page_id}")
 def page_resource(page_id: str) -> str:
-    """Return a Confluence page as a markdown MCP resource.
+    """Return a Confluence page as a Markdown MCP resource.
 
     Access via URI: confluence://page/{page_id}
-    The page body is converted from Confluence storage format to markdown.
+    The page body is converted from Confluence storage format to Markdown.
+    For lossless access use the storage variant: confluence://page/{page_id}/storage
     """
     client = _get_client()
     try:
@@ -361,6 +582,27 @@ def page_resource(page_id: str) -> str:
     md = client._html_to_markdown(html)
     title = data.get("title", page_id)
     return f"# {title}\n\n{md}"
+
+
+@mcp.resource("confluence://page/{page_id}/storage")
+def page_resource_storage(page_id: str) -> str:
+    """Return a Confluence page as a storage format (XHTML) MCP resource.
+
+    Access via URI: confluence://page/{page_id}/storage
+    Returns the raw Confluence storage format (XHTML) — Atlassian's official
+    native page format — pretty-printed for readability.  Tables, macros, and
+    layouts are preserved losslessly.
+    For Markdown access use: confluence://page/{page_id}
+    """
+    client = _get_client()
+    try:
+        data = client.get_page_content(page_id)
+    except Exception as e:
+        raise RuntimeError(f"Could not load page {page_id}: {e}") from e
+    html = data["body"]["storage"]["value"]
+    title = data.get("title", page_id)
+    pretty = client._prettify_storage(html)
+    return f"<!-- Title: {title} -->\n{pretty}"
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -371,3 +371,132 @@ class TestCLI:
         result = self._run("--clear-cache")
         assert result.returncode == 0
         assert "Cleared" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Confluence storage format helpers (Fase 0)
+# ---------------------------------------------------------------------------
+
+
+def _make_stub_client() -> ConfluenceClient:
+    """Return a ConfluenceClient without making any network calls."""
+    return ConfluenceClient(
+        base_url="https://confluence.example.com",
+        token="dummy-token",
+        cache_enabled=False,
+    )
+
+
+class TestValidateStorageXhtml:
+    """Unit tests for ConfluenceClient._validate_storage_xhtml."""
+
+    def setup_method(self):
+        self.client = _make_stub_client()
+
+    def _ok(self, html: str) -> None:
+        valid, err = self.client._validate_storage_xhtml(html)
+        assert valid is True, f"Expected valid, got error: {err}"
+        assert err is None
+
+    def _fail(self, html: str, fragment: str) -> None:
+        valid, err = self.client._validate_storage_xhtml(html)
+        assert valid is False, "Expected invalid, but validation passed"
+        assert err is not None
+        assert fragment in err, f"Expected {fragment!r} in error: {err!r}"
+
+    def test_simple_paragraph(self):
+        self._ok("<p>Hello world</p>")
+
+    def test_self_closing_br(self):
+        self._ok("<p>Line one<br/>Line two</p>")
+
+    def test_open_br_is_normalized_and_valid(self):
+        """<br> without slash should be auto-normalized to <br/> before validation."""
+        self._ok("<p>Line one<br>Line two</p>")
+
+    def test_void_img_normalized(self):
+        self._ok('<p><img src="x.png" alt="x"/></p>')
+
+    def test_open_img_normalized(self):
+        self._ok('<p><img src="x.png"></p>')
+
+    def test_confluence_macro_valid(self):
+        xhtml = (
+            '<ac:structured-macro ac:name="code">'
+            '<ac:parameter ac:name="language">python</ac:parameter>'
+            "<ac:plain-text-body><![CDATA[print('hello')]]></ac:plain-text-body>"
+            "</ac:structured-macro>"
+        )
+        self._ok(xhtml)
+
+    def test_ri_page_reference_valid(self):
+        self._ok('<ri:page ri:content-title="My Page"/>')
+
+    def test_table_with_colspan(self):
+        xhtml = (
+            "<table><tbody><tr>"
+            '<td colspan="2">merged</td>'
+            "</tr><tr>"
+            "<td>a</td><td>b</td>"
+            "</tr></tbody></table>"
+        )
+        self._ok(xhtml)
+
+    def test_bare_ampersand_rejected(self):
+        self._fail("<p>AT&T</p>", "&")
+
+    def test_entity_amp_ok(self):
+        self._ok("<p>AT&amp;T</p>")
+
+    def test_numeric_entity_ok(self):
+        self._ok("<p>space&#160;here</p>")
+
+    def test_hex_entity_ok(self):
+        self._ok("<p>space&#xA0;here</p>")
+
+    def test_unclosed_tag_rejected(self):
+        self._fail("<p>Not closed", "well-formed")
+
+    def test_mismatched_tags_rejected(self):
+        self._fail("<p>text</div>", "well-formed")
+
+    def test_empty_string_valid(self):
+        self._ok("")
+
+    def test_multiple_top_level_elements(self):
+        self._ok("<p>First</p><p>Second</p>")
+
+
+class TestPrettifyStorage:
+    """Unit tests for ConfluenceClient._prettify_storage."""
+
+    def setup_method(self):
+        self.client = _make_stub_client()
+
+    def test_adds_indentation(self):
+        result = self.client._prettify_storage("<div><p>Hello</p></div>")
+        assert "\n" in result
+        assert "Hello" in result
+
+    def test_preserves_ac_plain_text_body_content(self):
+        """Whitespace inside ac:plain-text-body must not be reflowed."""
+        inner = "def foo():\n    return 42"
+        html = f"<ac:plain-text-body>{inner}</ac:plain-text-body>"
+        result = self.client._prettify_storage(html)
+        assert inner in result
+
+    def test_preserves_pre_content(self):
+        inner = "  indented\n    more"
+        html = f"<pre>{inner}</pre>"
+        result = self.client._prettify_storage(html)
+        assert inner in result
+
+    def test_regular_elements_are_prettified(self):
+        html = "<div><p>Hello</p><p>World</p></div>"
+        result = self.client._prettify_storage(html)
+        # BeautifulSoup prettify adds newlines around block elements
+        assert result.count("\n") > 1
+
+    def test_returns_string(self):
+        result = self.client._prettify_storage("<p>hi</p>")
+        assert isinstance(result, str)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,365 @@
+"""Tests for the MCP server module (confluence_markdown.mcp_server).
+
+Strategy: patch `confluence_markdown.mcp_server._get_client` so every tool
+function receives a MagicMock instead of a real ConfluenceClient.  The module-
+level singleton `_client` is also reset between tests to avoid state leakage.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import confluence_markdown.mcp_server as mcp_mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_client(**overrides) -> MagicMock:
+    """Return a MagicMock that mimics ConfluenceClient."""
+    mock = MagicMock()
+    mock.base_url = "https://confluence.example.com"
+    mock._build_text_search_cql.return_value = 'text ~ "hello"'
+    mock.search_pages.return_value = [{"id": "1", "title": "Page A", "url": "https://confluence.example.com/a"}]
+    mock.read_page_content.return_value = {"id": "1", "title": "Page A", "markdown": "# Hello"}
+    mock.list_recent_pages.return_value = [{"id": "2", "title": "Recent", "url": "https://confluence.example.com/r"}]
+    mock.list_spaces.return_value = [{"key": "DEV", "name": "Development"}]
+    mock.list_children.return_value = [{"id": "3", "title": "Child", "url": "https://confluence.example.com/c"}]
+    mock.create_page.return_value = {"id": "42", "title": "New Page", "_links": {"webui": "/pages/42"}}
+    mock.edit_page_with_editor.return_value = {"id": "1", "title": "Page A", "version": {"number": 2}}
+    mock.add_content_to_page.return_value = {"id": "1", "title": "Page A", "version": {"number": 3}}
+    mock.get_page_content.return_value = {
+        "title": "Page A",
+        "body": {"storage": {"value": "<p>Hello</p>"}},
+    }
+    mock._html_to_markdown.return_value = "Hello"
+    for key, value in overrides.items():
+        setattr(mock, key, value)
+    return mock
+
+
+def _patch_client(mock: MagicMock):
+    """Context manager: patch _get_client and reset the module singleton."""
+    return patch.object(mcp_mod, "_get_client", return_value=mock)
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    """Reset the module-level _client singleton before each test."""
+    mcp_mod._client = None
+    yield
+    mcp_mod._client = None
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistration:
+    """Verify that all expected tools are registered on the FastMCP instance."""
+
+    def _tool_names(self) -> set[str]:
+        import asyncio
+        tools = asyncio.run(mcp_mod.mcp.list_tools())
+        return {t.name for t in tools}
+
+    def test_read_tools_registered(self):
+        names = self._tool_names()
+        for tool in ("search_pages", "get_page", "list_recent_pages", "list_spaces", "list_children"):
+            assert tool in names, f"Expected read tool '{tool}' to be registered"
+
+    def test_write_tools_registered(self):
+        """Write tools are always registered (gating is runtime, not registration-time)."""
+        names = self._tool_names()
+        for tool in ("create_page", "edit_page", "add_content_to_page"):
+            assert tool in names, f"Expected write tool '{tool}' to be registered"
+
+
+# ---------------------------------------------------------------------------
+# Read tools
+# ---------------------------------------------------------------------------
+
+
+class TestSearchPages:
+    def test_cql_search(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.search_pages(cql="space = DEV")
+        mock.search_pages.assert_called_once_with("space = DEV", 10)
+        data = json.loads(result)
+        assert data[0]["title"] == "Page A"
+
+    def test_text_query_builds_cql(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.search_pages(query="hello")
+        mock._build_text_search_cql.assert_called_once_with("hello")
+        mock.search_pages.assert_called_once_with('text ~ "hello"', 10)
+        assert "Page A" in result
+
+    def test_no_query_raises(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            with pytest.raises(ValueError, match="cql.*query"):
+                mcp_mod.search_pages()
+
+    def test_limit_clamped_to_50(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            mcp_mod.search_pages(cql="type = page", limit=999)
+        _, called_limit = mock.search_pages.call_args[0]
+        assert called_limit == 50
+
+    def test_confluence_error_raises_runtime(self):
+        from confluence_markdown.exceptions import ConfluenceError
+        mock = _make_client()
+        mock.search_pages.side_effect = ConfluenceError("boom")
+        with _patch_client(mock):
+            with pytest.raises(RuntimeError, match="boom"):
+                mcp_mod.search_pages(cql="type = page")
+
+
+class TestGetPage:
+    def test_returns_json(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.get_page("https://confluence.example.com/a")
+        mock.read_page_content.assert_called_once_with("https://confluence.example.com/a")
+        data = json.loads(result)
+        assert data["title"] == "Page A"
+
+    def test_confluence_error_raises_runtime(self):
+        from confluence_markdown.exceptions import ConfluenceError
+        mock = _make_client()
+        mock.read_page_content.side_effect = ConfluenceError("not found")
+        with _patch_client(mock):
+            with pytest.raises(RuntimeError, match="not found"):
+                mcp_mod.get_page("https://confluence.example.com/missing")
+
+
+class TestListRecentPages:
+    def test_returns_json_list(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.list_recent_pages(limit=5)
+        mock.list_recent_pages.assert_called_once_with(5)
+        data = json.loads(result)
+        assert data[0]["title"] == "Recent"
+
+    def test_limit_clamped(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            mcp_mod.list_recent_pages(limit=100)
+        mock.list_recent_pages.assert_called_once_with(50)
+
+
+class TestListSpaces:
+    def test_returns_json_list(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.list_spaces()
+        mock.list_spaces.assert_called_once()
+        data = json.loads(result)
+        assert data[0]["key"] == "DEV"
+
+
+class TestListChildren:
+    def test_returns_json_list(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.list_children("https://confluence.example.com/parent")
+        mock.list_children.assert_called_once_with("https://confluence.example.com/parent", 50)
+        data = json.loads(result)
+        assert data[0]["title"] == "Child"
+
+    def test_limit_clamped_to_200(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            mcp_mod.list_children("https://confluence.example.com/parent", limit=999)
+        _, called_limit = mock.list_children.call_args[0]
+        assert called_limit == 200
+
+
+# ---------------------------------------------------------------------------
+# Write tools
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePage:
+    def test_creates_page_and_returns_url(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.create_page(
+                space_key="DEV",
+                title="New Page",
+                content="# Hello",
+                parent_id=None,
+            )
+        mock.create_page.assert_called_once_with(
+            space_key="DEV",
+            title="New Page",
+            content="# Hello",
+            parent_id=None,
+            content_type="markdown",
+        )
+        data = json.loads(result)
+        assert data["id"] == "42"
+        assert "42" in data["url"]
+
+    def test_confluence_error_raises_runtime(self):
+        from confluence_markdown.exceptions import ConfluenceError
+        mock = _make_client()
+        mock.create_page.side_effect = ConfluenceError("space not found")
+        with _patch_client(mock):
+            with pytest.raises(RuntimeError, match="space not found"):
+                mcp_mod.create_page("MISSING", "Title", "body")
+
+
+class TestEditPage:
+    def test_edits_page_and_returns_metadata(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.edit_page("https://confluence.example.com/a", "# Updated")
+        mock.edit_page_with_editor.assert_called_once_with(
+            "https://confluence.example.com/a",
+            content="# Updated",
+            content_type="markdown",
+        )
+        data = json.loads(result)
+        assert data["version"] == 2
+
+    def test_confluence_error_raises_runtime(self):
+        from confluence_markdown.exceptions import ConfluenceError
+        mock = _make_client()
+        mock.edit_page_with_editor.side_effect = ConfluenceError("conflict")
+        with _patch_client(mock):
+            with pytest.raises(RuntimeError, match="conflict"):
+                mcp_mod.edit_page("https://confluence.example.com/a", "body")
+
+
+class TestAddContentToPage:
+    def test_appends_content(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.add_content_to_page(
+                "https://confluence.example.com/a", "## New section", append=True
+            )
+        mock.add_content_to_page.assert_called_once_with(
+            "https://confluence.example.com/a",
+            "## New section",
+            append=True,
+            content_type="markdown",
+        )
+        data = json.loads(result)
+        assert data["version"] == 3
+
+    def test_prepends_content(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            mcp_mod.add_content_to_page(
+                "https://confluence.example.com/a", "## Intro", append=False
+            )
+        mock.add_content_to_page.assert_called_once_with(
+            "https://confluence.example.com/a",
+            "## Intro",
+            append=False,
+            content_type="markdown",
+        )
+
+    def test_confluence_error_raises_runtime(self):
+        from confluence_markdown.exceptions import ConfluenceError
+        mock = _make_client()
+        mock.add_content_to_page.side_effect = ConfluenceError("page locked")
+        with _patch_client(mock):
+            with pytest.raises(RuntimeError, match="page locked"):
+                mcp_mod.add_content_to_page("https://confluence.example.com/a", "body")
+
+
+# ---------------------------------------------------------------------------
+# MCP Resource
+# ---------------------------------------------------------------------------
+
+
+class TestPageResource:
+    def test_returns_markdown_with_title(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.page_resource("12345")
+        mock.get_page_content.assert_called_once_with("12345")
+        assert result.startswith("# Page A")
+        assert "Hello" in result
+
+    def test_error_raises_runtime(self):
+        mock = _make_client()
+        mock.get_page_content.side_effect = Exception("network error")
+        with _patch_client(mock):
+            with pytest.raises(RuntimeError, match="network error"):
+                mcp_mod.page_resource("99999")
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution (_get_client)
+# ---------------------------------------------------------------------------
+
+
+class TestGetClient:
+    def test_env_vars_used_when_set(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://env.example.com")
+        monkeypatch.setenv("CONFLUENCE_TOKEN", "tok123")
+        monkeypatch.delenv("CONFLUENCE_USERNAME", raising=False)
+        monkeypatch.delenv("CONFLUENCE_PASSWORD", raising=False)
+
+        with patch("confluence_markdown.mcp_server.ConfigManager") as MockCM, \
+             patch("confluence_markdown.mcp_server.ConfluenceClient") as MockCC:
+            MockCM.return_value.load_config.return_value = {}
+            MockCC.return_value = MagicMock()
+            mcp_mod._get_client()
+
+        MockCC.assert_called_once()
+        call_kwargs = MockCC.call_args[1]
+        assert call_kwargs["base_url"] == "https://env.example.com"
+        assert call_kwargs["token"] == "tok123"
+
+    def test_missing_base_url_raises_configuration_error(self, monkeypatch):
+        from confluence_markdown.exceptions import ConfigurationError
+        monkeypatch.delenv("CONFLUENCE_URL", raising=False)
+        monkeypatch.delenv("CONFLUENCE_TOKEN", raising=False)
+        monkeypatch.delenv("CONFLUENCE_USERNAME", raising=False)
+        monkeypatch.delenv("CONFLUENCE_PASSWORD", raising=False)
+
+        with patch("confluence_markdown.mcp_server.ConfigManager") as MockCM:
+            MockCM.return_value.load_config.return_value = {}
+            with pytest.raises(ConfigurationError, match="base_url"):
+                mcp_mod._get_client()
+
+    def test_missing_credentials_raises_configuration_error(self, monkeypatch):
+        from confluence_markdown.exceptions import ConfigurationError
+        monkeypatch.setenv("CONFLUENCE_URL", "https://env.example.com")
+        monkeypatch.delenv("CONFLUENCE_TOKEN", raising=False)
+        monkeypatch.delenv("CONFLUENCE_USERNAME", raising=False)
+        monkeypatch.delenv("CONFLUENCE_PASSWORD", raising=False)
+
+        with patch("confluence_markdown.mcp_server.ConfigManager") as MockCM:
+            MockCM.return_value.load_config.return_value = {}
+            with pytest.raises(ConfigurationError, match="credentials"):
+                mcp_mod._get_client()
+
+    def test_singleton_cached(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://env.example.com")
+        monkeypatch.setenv("CONFLUENCE_TOKEN", "tok123")
+
+        with patch("confluence_markdown.mcp_server.ConfigManager") as MockCM, \
+             patch("confluence_markdown.mcp_server.ConfluenceClient") as MockCC:
+            MockCM.return_value.load_config.return_value = {}
+            MockCC.return_value = MagicMock()
+            c1 = mcp_mod._get_client()
+            c2 = mcp_mod._get_client()
+
+        assert c1 is c2
+        MockCC.assert_called_once()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7,12 +7,15 @@ level singleton `_client` is also reset between tests to avoid state leakage.
 
 from __future__ import annotations
 
+import asyncio
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import confluence_markdown.mcp_server as mcp_mod
+from mcp.server.elicitation import AcceptedElicitation
+from confluence_markdown.mcp_server import WriteConfirmation
 
 
 # ---------------------------------------------------------------------------
@@ -46,6 +49,16 @@ def _make_client(**overrides) -> MagicMock:
 def _patch_client(mock: MagicMock):
     """Context manager: patch _get_client and reset the module singleton."""
     return patch.object(mcp_mod, "_get_client", return_value=mock)
+
+
+def _make_ctx(confirm: bool = True, remember: bool = False, supports_elicitation: bool = True) -> MagicMock:
+    """Return a mock Context whose elicit() returns an AcceptedElicitation."""
+    ctx = MagicMock()
+    ctx.session.check_client_capability.return_value = supports_elicitation
+    ctx.elicit = AsyncMock(
+        return_value=AcceptedElicitation(data=WriteConfirmation(confirm=confirm, remember=remember))
+    )
+    return ctx
 
 
 @pytest.fixture(autouse=True)
@@ -194,13 +207,15 @@ class TestListChildren:
 class TestCreatePage:
     def test_creates_page_and_returns_url(self):
         mock = _make_client()
+        ctx = _make_ctx()
         with _patch_client(mock):
-            result = mcp_mod.create_page(
+            result = asyncio.run(mcp_mod.create_page(
                 space_key="DEV",
                 title="New Page",
                 content="# Hello",
+                ctx=ctx,
                 parent_id=None,
-            )
+            ))
         mock.create_page.assert_called_once_with(
             space_key="DEV",
             title="New Page",
@@ -216,16 +231,20 @@ class TestCreatePage:
         from confluence_markdown.exceptions import ConfluenceError
         mock = _make_client()
         mock.create_page.side_effect = ConfluenceError("space not found")
+        ctx = _make_ctx()
         with _patch_client(mock):
             with pytest.raises(RuntimeError, match="space not found"):
-                mcp_mod.create_page("MISSING", "Title", "body")
+                asyncio.run(mcp_mod.create_page("MISSING", "Title", "body", ctx=ctx))
 
 
 class TestEditPage:
     def test_edits_page_and_returns_metadata(self):
         mock = _make_client()
+        ctx = _make_ctx()
         with _patch_client(mock):
-            result = mcp_mod.edit_page("https://confluence.example.com/a", "# Updated")
+            result = asyncio.run(
+                mcp_mod.edit_page("https://confluence.example.com/a", "# Updated", ctx=ctx)
+            )
         mock.edit_page_with_editor.assert_called_once_with(
             "https://confluence.example.com/a",
             content="# Updated",
@@ -238,18 +257,20 @@ class TestEditPage:
         from confluence_markdown.exceptions import ConfluenceError
         mock = _make_client()
         mock.edit_page_with_editor.side_effect = ConfluenceError("conflict")
+        ctx = _make_ctx()
         with _patch_client(mock):
             with pytest.raises(RuntimeError, match="conflict"):
-                mcp_mod.edit_page("https://confluence.example.com/a", "body")
+                asyncio.run(mcp_mod.edit_page("https://confluence.example.com/a", "body", ctx=ctx))
 
 
 class TestAddContentToPage:
     def test_appends_content(self):
         mock = _make_client()
+        ctx = _make_ctx()
         with _patch_client(mock):
-            result = mcp_mod.add_content_to_page(
-                "https://confluence.example.com/a", "## New section", append=True
-            )
+            result = asyncio.run(mcp_mod.add_content_to_page(
+                "https://confluence.example.com/a", "## New section", ctx=ctx, append=True
+            ))
         mock.add_content_to_page.assert_called_once_with(
             "https://confluence.example.com/a",
             "## New section",
@@ -261,10 +282,11 @@ class TestAddContentToPage:
 
     def test_prepends_content(self):
         mock = _make_client()
+        ctx = _make_ctx()
         with _patch_client(mock):
-            mcp_mod.add_content_to_page(
-                "https://confluence.example.com/a", "## Intro", append=False
-            )
+            asyncio.run(mcp_mod.add_content_to_page(
+                "https://confluence.example.com/a", "## Intro", ctx=ctx, append=False
+            ))
         mock.add_content_to_page.assert_called_once_with(
             "https://confluence.example.com/a",
             "## Intro",
@@ -276,9 +298,12 @@ class TestAddContentToPage:
         from confluence_markdown.exceptions import ConfluenceError
         mock = _make_client()
         mock.add_content_to_page.side_effect = ConfluenceError("page locked")
+        ctx = _make_ctx()
         with _patch_client(mock):
             with pytest.raises(RuntimeError, match="page locked"):
-                mcp_mod.add_content_to_page("https://confluence.example.com/a", "body")
+                asyncio.run(mcp_mod.add_content_to_page(
+                    "https://confluence.example.com/a", "body", ctx=ctx
+                ))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2,7 +2,8 @@
 
 Strategy: patch `confluence_markdown.mcp_server._get_client` so every tool
 function receives a MagicMock instead of a real ConfluenceClient.  The module-
-level singleton `_client` is also reset between tests to avoid state leakage.
+level singletons (_client, _writes_confirmed_session) are also reset between
+tests to avoid state leakage.
 """
 
 from __future__ import annotations
@@ -29,7 +30,16 @@ def _make_client(**overrides) -> MagicMock:
     mock.base_url = "https://confluence.example.com"
     mock._build_text_search_cql.return_value = 'text ~ "hello"'
     mock.search_pages.return_value = [{"id": "1", "title": "Page A", "url": "https://confluence.example.com/a"}]
-    mock.read_page_content.return_value = {"id": "1", "title": "Page A", "markdown": "# Hello"}
+    mock.read_page_content.return_value = {
+        "id": "1",
+        "title": "Page A",
+        "space": "Dev",
+        "space_key": "DEV",
+        "version": 1,
+        "url": "https://confluence.example.com/a",
+        "html_content": "<p>Hello</p>",
+        "markdown_content": "Hello",
+    }
     mock.list_recent_pages.return_value = [{"id": "2", "title": "Recent", "url": "https://confluence.example.com/r"}]
     mock.list_spaces.return_value = [{"key": "DEV", "name": "Development"}]
     mock.list_children.return_value = [{"id": "3", "title": "Child", "url": "https://confluence.example.com/c"}]
@@ -41,6 +51,8 @@ def _make_client(**overrides) -> MagicMock:
         "body": {"storage": {"value": "<p>Hello</p>"}},
     }
     mock._html_to_markdown.return_value = "Hello"
+    mock._prettify_storage.return_value = "<p>Hello</p>"
+    mock._validate_storage_xhtml.return_value = (True, None)
     for key, value in overrides.items():
         setattr(mock, key, value)
     return mock
@@ -63,10 +75,12 @@ def _make_ctx(confirm: bool = True, remember: bool = False, supports_elicitation
 
 @pytest.fixture(autouse=True)
 def reset_singleton():
-    """Reset the module-level _client singleton before each test."""
+    """Reset module-level singletons before each test."""
     mcp_mod._client = None
+    mcp_mod._writes_confirmed_session = False
     yield
     mcp_mod._client = None
+    mcp_mod._writes_confirmed_session = False
 
 
 # ---------------------------------------------------------------------------
@@ -78,24 +92,33 @@ class TestToolRegistration:
     """Verify that all expected tools are registered on the FastMCP instance."""
 
     def _tool_names(self) -> set[str]:
-        import asyncio
         tools = asyncio.run(mcp_mod.mcp.list_tools())
         return {t.name for t in tools}
 
-    def test_read_tools_registered(self):
+    def test_navigation_tools_registered(self):
         names = self._tool_names()
-        for tool in ("search_pages", "get_page", "list_recent_pages", "list_spaces", "list_children"):
-            assert tool in names, f"Expected read tool '{tool}' to be registered"
+        for tool in ("search_pages", "list_recent_pages", "list_spaces", "list_children"):
+            assert tool in names, f"Expected navigation tool '{tool}' to be registered"
 
-    def test_write_tools_registered(self):
-        """Write tools are always registered (gating is runtime, not registration-time)."""
+    def test_md_tools_registered(self):
         names = self._tool_names()
-        for tool in ("create_page", "edit_page", "add_content_to_page"):
-            assert tool in names, f"Expected write tool '{tool}' to be registered"
+        for tool in ("get_page_md", "create_page_md", "edit_page_md", "add_content_md"):
+            assert tool in names, f"Expected *_md tool '{tool}' to be registered"
+
+    def test_storage_tools_registered(self):
+        names = self._tool_names()
+        for tool in ("get_page_storage", "create_page_storage", "edit_page_storage", "add_content_storage"):
+            assert tool in names, f"Expected *_storage tool '{tool}' to be registered"
+
+    def test_old_tool_names_not_present(self):
+        """Ensure the pre-rename tool names are gone (breaking-change clean cut)."""
+        names = self._tool_names()
+        for old in ("get_page", "create_page", "edit_page", "add_content_to_page"):
+            assert old not in names, f"Old tool name '{old}' should have been removed"
 
 
 # ---------------------------------------------------------------------------
-# Read tools
+# Navigation / search tools
 # ---------------------------------------------------------------------------
 
 
@@ -136,24 +159,6 @@ class TestSearchPages:
         with _patch_client(mock):
             with pytest.raises(RuntimeError, match="boom"):
                 mcp_mod.search_pages(cql="type = page")
-
-
-class TestGetPage:
-    def test_returns_json(self):
-        mock = _make_client()
-        with _patch_client(mock):
-            result = mcp_mod.get_page("https://confluence.example.com/a")
-        mock.read_page_content.assert_called_once_with("https://confluence.example.com/a")
-        data = json.loads(result)
-        assert data["title"] == "Page A"
-
-    def test_confluence_error_raises_runtime(self):
-        from confluence_markdown.exceptions import ConfluenceError
-        mock = _make_client()
-        mock.read_page_content.side_effect = ConfluenceError("not found")
-        with _patch_client(mock):
-            with pytest.raises(RuntimeError, match="not found"):
-                mcp_mod.get_page("https://confluence.example.com/missing")
 
 
 class TestListRecentPages:
@@ -200,16 +205,34 @@ class TestListChildren:
 
 
 # ---------------------------------------------------------------------------
-# Write tools
+# *_md tools
 # ---------------------------------------------------------------------------
 
 
-class TestCreatePage:
+class TestGetPageMd:
+    def test_returns_json(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.get_page_md("https://confluence.example.com/a")
+        mock.read_page_content.assert_called_once_with("https://confluence.example.com/a")
+        data = json.loads(result)
+        assert data["title"] == "Page A"
+
+    def test_confluence_error_raises_runtime(self):
+        from confluence_markdown.exceptions import ConfluenceError
+        mock = _make_client()
+        mock.read_page_content.side_effect = ConfluenceError("not found")
+        with _patch_client(mock):
+            with pytest.raises(RuntimeError, match="not found"):
+                mcp_mod.get_page_md("https://confluence.example.com/missing")
+
+
+class TestCreatePageMd:
     def test_creates_page_and_returns_url(self):
         mock = _make_client()
         ctx = _make_ctx()
         with _patch_client(mock):
-            result = asyncio.run(mcp_mod.create_page(
+            result = asyncio.run(mcp_mod.create_page_md(
                 space_key="DEV",
                 title="New Page",
                 content="# Hello",
@@ -234,16 +257,16 @@ class TestCreatePage:
         ctx = _make_ctx()
         with _patch_client(mock):
             with pytest.raises(RuntimeError, match="space not found"):
-                asyncio.run(mcp_mod.create_page("MISSING", "Title", "body", ctx=ctx))
+                asyncio.run(mcp_mod.create_page_md("MISSING", "Title", "body", ctx=ctx))
 
 
-class TestEditPage:
+class TestEditPageMd:
     def test_edits_page_and_returns_metadata(self):
         mock = _make_client()
         ctx = _make_ctx()
         with _patch_client(mock):
             result = asyncio.run(
-                mcp_mod.edit_page("https://confluence.example.com/a", "# Updated", ctx=ctx)
+                mcp_mod.edit_page_md("https://confluence.example.com/a", "# Updated", ctx=ctx)
             )
         mock.edit_page_with_editor.assert_called_once_with(
             "https://confluence.example.com/a",
@@ -260,15 +283,15 @@ class TestEditPage:
         ctx = _make_ctx()
         with _patch_client(mock):
             with pytest.raises(RuntimeError, match="conflict"):
-                asyncio.run(mcp_mod.edit_page("https://confluence.example.com/a", "body", ctx=ctx))
+                asyncio.run(mcp_mod.edit_page_md("https://confluence.example.com/a", "body", ctx=ctx))
 
 
-class TestAddContentToPage:
+class TestAddContentMd:
     def test_appends_content(self):
         mock = _make_client()
         ctx = _make_ctx()
         with _patch_client(mock):
-            result = asyncio.run(mcp_mod.add_content_to_page(
+            result = asyncio.run(mcp_mod.add_content_md(
                 "https://confluence.example.com/a", "## New section", ctx=ctx, append=True
             ))
         mock.add_content_to_page.assert_called_once_with(
@@ -284,7 +307,7 @@ class TestAddContentToPage:
         mock = _make_client()
         ctx = _make_ctx()
         with _patch_client(mock):
-            asyncio.run(mcp_mod.add_content_to_page(
+            asyncio.run(mcp_mod.add_content_md(
                 "https://confluence.example.com/a", "## Intro", ctx=ctx, append=False
             ))
         mock.add_content_to_page.assert_called_once_with(
@@ -301,13 +324,164 @@ class TestAddContentToPage:
         ctx = _make_ctx()
         with _patch_client(mock):
             with pytest.raises(RuntimeError, match="page locked"):
-                asyncio.run(mcp_mod.add_content_to_page(
+                asyncio.run(mcp_mod.add_content_md(
                     "https://confluence.example.com/a", "body", ctx=ctx
                 ))
 
 
 # ---------------------------------------------------------------------------
-# MCP Resource
+# *_storage tools
+# ---------------------------------------------------------------------------
+
+
+class TestGetPageStorage:
+    def test_returns_storage_content(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.get_page_storage("https://confluence.example.com/a")
+        mock.read_page_content.assert_called_once_with("https://confluence.example.com/a")
+        mock._prettify_storage.assert_called_once_with("<p>Hello</p>")
+        data = json.loads(result)
+        assert data["title"] == "Page A"
+        assert "storage_content" in data
+        assert "markdown_content" not in data  # storage tool does not return markdown
+
+    def test_confluence_error_raises_runtime(self):
+        from confluence_markdown.exceptions import ConfluenceError
+        mock = _make_client()
+        mock.read_page_content.side_effect = ConfluenceError("not found")
+        with _patch_client(mock):
+            with pytest.raises(RuntimeError, match="not found"):
+                mcp_mod.get_page_storage("https://confluence.example.com/missing")
+
+
+class TestCreatePageStorage:
+    def test_creates_page_with_storage_content(self):
+        mock = _make_client()
+        ctx = _make_ctx()
+        xhtml = "<p>Hello <strong>world</strong></p>"
+        with _patch_client(mock):
+            result = asyncio.run(mcp_mod.create_page_storage(
+                space_key="DEV",
+                title="New Page",
+                content=xhtml,
+                ctx=ctx,
+            ))
+        mock._validate_storage_xhtml.assert_called_once_with(xhtml)
+        mock.create_page.assert_called_once_with(
+            space_key="DEV",
+            title="New Page",
+            content=xhtml,
+            parent_id=None,
+            content_type="html",
+        )
+        data = json.loads(result)
+        assert data["id"] == "42"
+        assert "42" in data["url"]
+
+    def test_invalid_xhtml_raises_value_error(self):
+        mock = _make_client()
+        mock._validate_storage_xhtml.return_value = (False, "unclosed tag <p>")
+        ctx = _make_ctx()
+        with _patch_client(mock):
+            with pytest.raises(ValueError, match="unclosed tag"):
+                asyncio.run(mcp_mod.create_page_storage(
+                    "DEV", "Title", "<p>broken", ctx=ctx
+                ))
+
+    def test_confluence_error_raises_runtime(self):
+        from confluence_markdown.exceptions import ConfluenceError
+        mock = _make_client()
+        mock.create_page.side_effect = ConfluenceError("space not found")
+        ctx = _make_ctx()
+        with _patch_client(mock):
+            with pytest.raises(RuntimeError, match="space not found"):
+                asyncio.run(mcp_mod.create_page_storage("MISSING", "Title", "<p/>", ctx=ctx))
+
+
+class TestEditPageStorage:
+    def test_edits_page_with_storage_content(self):
+        mock = _make_client()
+        ctx = _make_ctx()
+        xhtml = "<p>Updated <strong>content</strong></p>"
+        with _patch_client(mock):
+            result = asyncio.run(
+                mcp_mod.edit_page_storage("https://confluence.example.com/a", xhtml, ctx=ctx)
+            )
+        mock._validate_storage_xhtml.assert_called_once_with(xhtml)
+        mock.edit_page_with_editor.assert_called_once_with(
+            "https://confluence.example.com/a",
+            content=xhtml,
+            content_type="storage",
+        )
+        data = json.loads(result)
+        assert data["version"] == 2
+
+    def test_invalid_xhtml_raises_value_error(self):
+        mock = _make_client()
+        mock._validate_storage_xhtml.return_value = (False, "bare & detected")
+        ctx = _make_ctx()
+        with _patch_client(mock):
+            with pytest.raises(ValueError, match="bare &"):
+                asyncio.run(
+                    mcp_mod.edit_page_storage("https://confluence.example.com/a", "bad & content", ctx=ctx)
+                )
+
+    def test_confluence_error_raises_runtime(self):
+        from confluence_markdown.exceptions import ConfluenceError
+        mock = _make_client()
+        mock.edit_page_with_editor.side_effect = ConfluenceError("conflict")
+        ctx = _make_ctx()
+        with _patch_client(mock):
+            with pytest.raises(RuntimeError, match="conflict"):
+                asyncio.run(
+                    mcp_mod.edit_page_storage("https://confluence.example.com/a", "<p/>", ctx=ctx)
+                )
+
+
+class TestAddContentStorage:
+    def test_appends_storage_content(self):
+        mock = _make_client()
+        ctx = _make_ctx()
+        xhtml = "<p>Appended</p>"
+        with _patch_client(mock):
+            result = asyncio.run(mcp_mod.add_content_storage(
+                "https://confluence.example.com/a", xhtml, ctx=ctx, append=True
+            ))
+        mock._validate_storage_xhtml.assert_called_once_with(xhtml)
+        mock.add_content_to_page.assert_called_once_with(
+            "https://confluence.example.com/a",
+            xhtml,
+            append=True,
+            content_type="html",
+        )
+        data = json.loads(result)
+        assert data["version"] == 3
+
+    def test_invalid_xhtml_raises_value_error(self):
+        mock = _make_client()
+        mock._validate_storage_xhtml.return_value = (False, "unclosed tag")
+        ctx = _make_ctx()
+        with _patch_client(mock):
+            with pytest.raises(ValueError, match="unclosed tag"):
+                asyncio.run(mcp_mod.add_content_storage(
+                    "https://confluence.example.com/a", "<p>broken", ctx=ctx
+                ))
+
+    def test_confluence_error_raises_runtime(self):
+        from confluence_markdown.exceptions import ConfluenceError
+        mock = _make_client()
+        mock.add_content_to_page.side_effect = ConfluenceError("page locked")
+        ctx = _make_ctx()
+        with _patch_client(mock):
+            with pytest.raises(RuntimeError, match="page locked"):
+                asyncio.run(mcp_mod.add_content_storage(
+                    "https://confluence.example.com/a", "<p/>", ctx=ctx
+                ))
+
+
+# ---------------------------------------------------------------------------
+# MCP Resources
 # ---------------------------------------------------------------------------
 
 
@@ -326,6 +500,56 @@ class TestPageResource:
         with _patch_client(mock):
             with pytest.raises(RuntimeError, match="network error"):
                 mcp_mod.page_resource("99999")
+
+
+class TestPageResourceStorage:
+    def test_returns_storage_xhtml(self):
+        mock = _make_client()
+        with _patch_client(mock):
+            result = mcp_mod.page_resource_storage("12345")
+        mock.get_page_content.assert_called_once_with("12345")
+        mock._prettify_storage.assert_called_once_with("<p>Hello</p>")
+        assert "Page A" in result
+
+    def test_error_raises_runtime(self):
+        mock = _make_client()
+        mock.get_page_content.side_effect = Exception("network error")
+        with _patch_client(mock):
+            with pytest.raises(RuntimeError, match="network error"):
+                mcp_mod.page_resource_storage("99999")
+
+
+# ---------------------------------------------------------------------------
+# Human-in-the-loop confirmation (_confirm_write)
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmWrite:
+    def test_no_elicitation_support_proceeds(self):
+        mock = _make_client()
+        ctx = _make_ctx(supports_elicitation=False)
+        with _patch_client(mock):
+            # Should NOT raise even though we never elicit
+            asyncio.run(mcp_mod.edit_page_md("https://confluence.example.com/a", "body", ctx=ctx))
+        ctx.elicit.assert_not_called()
+
+    def test_user_declines_raises_permission_error(self):
+        from mcp.server.elicitation import DeclinedElicitation
+        mock = _make_client()
+        ctx = _make_ctx()
+        ctx.elicit = AsyncMock(return_value=DeclinedElicitation())
+        with _patch_client(mock):
+            with pytest.raises(PermissionError):
+                asyncio.run(mcp_mod.edit_page_md("https://confluence.example.com/a", "body", ctx=ctx))
+
+    def test_remember_skips_subsequent_prompts(self):
+        mock = _make_client()
+        ctx = _make_ctx(remember=True)
+        with _patch_client(mock):
+            asyncio.run(mcp_mod.edit_page_md("https://confluence.example.com/a", "body", ctx=ctx))
+            # Second call: _writes_confirmed_session is True, elicit should not be called again
+            asyncio.run(mcp_mod.edit_page_md("https://confluence.example.com/b", "body", ctx=ctx))
+        assert ctx.elicit.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/todos.md
+++ b/todos.md
@@ -6,6 +6,7 @@
 - [ ] Tests: Keyring-Fallback-Pfad
 
 ## Completed
+- [x] Feat: Confluence storage format (XHTML) mode — lossless round-trips for tables/macros without Markdown conversion. MCP: `*_storage` tools (preferred for agents) + `*_md` tools (renamed); CLI `--format md|storage`; `_validate_storage_xhtml` + `_prettify_storage` helpers; bug fix for `content_type="html"` in `edit_page_with_editor`. **BREAKING:** MCP tools `get_page`/`edit_page`/`create_page`/`add_content_to_page` renamed to `*_md` suffix. | Completed: 06-22-2026
 - [x] Feat: Human-in-the-Loop-Bestätigung für Schreib-Tools via MCP-Elicitation (`create_page`, `edit_page`, `add_content_to_page`); Fail-Safe bei fehlendem Elicitation-Support; Session-Flag `_writes_confirmed_session` für "Merken"-Option (mcp_server.py) | Completed: 06-19-2026
 - [x] Fix: Keyring-Fallback mit expliziter Warnung statt silent Plaintext (config.py:81-85) | Completed: 05-17-2026
 - [x] Fix: print() → logger.error() in client.py (alle Stellen) | Completed: 05-17-2026

--- a/todos.md
+++ b/todos.md
@@ -6,6 +6,7 @@
 - [ ] Tests: Keyring-Fallback-Pfad
 
 ## Completed
+- [x] Feat: Human-in-the-Loop-Bestätigung für Schreib-Tools via MCP-Elicitation (`create_page`, `edit_page`, `add_content_to_page`); Fail-Safe bei fehlendem Elicitation-Support; Session-Flag `_writes_confirmed_session` für "Merken"-Option (mcp_server.py) | Completed: 06-19-2026
 - [x] Fix: Keyring-Fallback mit expliziter Warnung statt silent Plaintext (config.py:81-85) | Completed: 05-17-2026
 - [x] Fix: print() → logger.error() in client.py (alle Stellen) | Completed: 05-17-2026
 - [x] Fix: Auth-Header-Redaction vervollständigen (client.py:1547) | Completed: 05-17-2026


### PR DESCRIPTION
## Summary

Adds a lossless **Confluence storage format (XHTML)** mode alongside the existing Markdown path. Confluence storage format is Atlassian's official native page representation ([docs](https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html)) — the same `representation:"storage"` the REST API reads and writes. A pure passthrough: no conversion means no table/macro loss.

### Why

The Markdown round-trip silently destroys:
- Tables with `colspan`/`rowspan` or multi-paragraph cells
- Confluence macros (`ac:structured-macro`, task lists, …)
- Layouts and nested content

Agents using the MCP server in particular need a lossless edit path.

### What changed

**`client.py`**
- `_validate_storage_xhtml(html) -> (bool, str|None)` — normalises `<br>`/void elements, detects bare `&`, validates with `xml.etree.ElementTree`. Rejects malformed XHTML locally with a clear message before any API call.
- `_prettify_storage(html) -> str` — pretty-prints storage XHTML while preserving significant whitespace in `<pre>`, `<ac:plain-text-body>`, `<ac:plain-text-link-body>`.
- `download_page()` (renamed from `download_as_markdown`): `fmt="md"|"storage"` parameter.
- `edit_page_with_editor()` **bug fix**: `content_type="html"/"storage"` non-interactive path now validates + PUTs directly. Removes the former lossy `html→md→html` round-trip.

**`mcp_server.py`** — ⚠️ BREAKING: tool renames

| Old name | New name |
|---|---|
| `get_page` | `get_page_md` |
| `edit_page` | `edit_page_md` |
| `create_page` | `create_page_md` |
| `add_content_to_page` | `add_content_md` |

New `*_storage` family (agent-preferred, lossless XHTML):
- `get_page_storage`, `edit_page_storage`, `create_page_storage`, `add_content_storage`
- All validate XHTML before upload; all preserve the elicitation human-in-the-loop confirmation.

Server `instructions` updated to steer agents toward `*_storage` tools.  
New MCP resource: `confluence://page/{id}/storage`.  
Navigation/search tools (`search_pages`, `list_recent_pages`, `list_spaces`, `list_children`) unchanged.

**`cli.py`**: `--format {md,storage}` flag for `download` and `edit`.

**Tests**: 34 new unit tests — helpers, `*_storage` tools, renames, resources. 101 tests total, all green. `ruff` clean.

**Docs**: README "Confluence storage format mode" section, updated MCP tool table, CHANGELOG breaking-change entry, `todos.md` item marked Completed.

## Test plan

- [ ] `uv run pytest` — 101 tests pass
- [ ] `uv run ruff check` — no issues
- [ ] `confluence-markdown download <url> --format storage` → writes prettified XHTML with comment header
- [ ] `confluence-markdown edit <url> --format storage --content '<p>hello</p>'` → uploads without Markdown conversion
- [ ] MCP `get_page_storage` returns `storage_content` field (not `markdown_content`)
- [ ] MCP `edit_page_storage` with malformed XHTML → local error with clear message, no HTTP 400
- [ ] MCP `edit_page_storage` with valid XHTML → elicitation prompt, then upload
- [ ] MCP `edit_page_md` still works (renamed, behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)